### PR TITLE
Backport 22742: Remove width from video conferencing icon in user popover

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/skin/enterprise.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/skin/enterprise.less
@@ -2203,9 +2203,9 @@ p, .postContent, .uiWikiContentDisplay{
 }
 
 #tiptip_content .connectAction .btn {
-  width: 40px;
+  width: auto;
   height: 35px;
-  padding: 0 10px;
+  padding: 0;
 }
 .uiUserInvitation {
   .btn {


### PR DESCRIPTION
(cherry picked from commit a4f40c54b334739c272362a2b940470889626892)