### PR TITLE
fix/Maint-26892: See All is not displayed

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
@@ -24817,5 +24817,10 @@ html.overflow-y-hidden {
     float: right !important;
   }
 }
+@media all and (max-width: @minTabletWidth) {
+  .v-btn:not(.v-btn--round).v-size--small {
+    margin-top: -43px;
+  }
+}
 
 /*# sourceMappingURL=vuetify.css.map*/


### PR DESCRIPTION
In mobile, the button See All of News displayed, since it take the css of class .v-application .d-none {
  display: none !important;
}, 
I removed this class from this button 'See All', and i add a css to position this button in view mobile