### PR TITLE
MAINT-27214: Make sure that the action buttons of the comment input container are not hidden by the navigation bar on mobile device.

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -2534,6 +2534,15 @@
 
 
 @media (max-width: 480px) {
+  .uiSpaceActivitiesContainer {
+    .activityStream {
+      .contentBox .commentBox {
+        .inputContainer.inputContainerShow {
+          margin-bottom: 54px;
+        }
+      }
+    }
+  }
   .activityStream {
     .introBox .pull-left {
       display: block;


### PR DESCRIPTION
On mobile device in the space's activity stream the comment section's action buttons are hidden by the space's navigation bar which is in the footer of the page, i added a bottom margin in order to make the comment action buttons visible in space's activity stream only while in the main activity stream there is no bottom navigation bar.