### PR TITLE
MAINT-27573: Remove minus "-" symbol displayed before comments number on mobile 

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -1553,20 +1553,12 @@
         font-size: 13px;
       }
       .KudosNumber {
-        &:before {
-          content: '-';
-          padding-left: 4px;
-          padding-right: 4px;
-        }
+        padding-left: 4px;
+        padding-right: 4px;
       }
-
-
-       .CommentsNumber {
-        &:before {
-          content: '-';
-          padding-left: 4px;
-          padding-right: 4px;
-        }
+      .CommentsNumber {
+        padding-left: 4px;
+        padding-right: 4px;
       }
     }
 


### PR DESCRIPTION
Backport [commit](https://github.com/Meeds-io/platform-ui/commit/304b69791db541ada5ee493e6eecd9f069fa988f)