### PR TITLE
MAINT-26764: Reaction labels (Reply and kudos) not colored in blue in comment section

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -935,7 +935,7 @@
           margin-left: 3px;
         }
 
-        .commentLiked {
+        .commentLiked, .replyComment {
           color: @primaryColor;
         }
       }


### PR DESCRIPTION
Backport [commit](https://github.com/Meeds-io/platform-ui/commit/cee563c132f2972b458a2f41204f377a300d9f19)