### PR TITLE
Fix notifications drawer header and footer style for mobile

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
@@ -166,6 +166,8 @@ body.decrease-z-index-more #UITopBarContainer {
         border-bottom: 1px solid rgba(13, 13, 13, 0.05);
         background: white;
         z-index: 9999;
+        max-width: 100%;
+        box-sizing: border-box;
         .notifDrawerTitle {
           font-size: 18px;
           font-weight: bold;
@@ -389,6 +391,8 @@ body.decrease-z-index-more #UITopBarContainer {
         border-top: 1px solid rgba(13, 13, 13, 0.05);
         background: white;
         padding-right: 12px;
+        max-width: 100%;
+        box-sizing: border-box;
         .seeAllNotif {
           border: 1px solid @primaryColor !important;
           margin-top: 13px;


### PR DESCRIPTION
In mobile the width of footer and header of notifications drawer is larger than screen. This patch will add a `max-width` and `box-sizing` properties to fix the maximum width to allow for header and footer.