### PR TITLE
Fix Activity Stream width in mobile

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -1710,6 +1710,9 @@
           display: inline-flex;
           max-width: 100%;
           width: 100%;
+          &.subCommentShowAll {
+            width: auto;
+          }
           .actLink {
             position: relative;
             top: 0px;


### PR DESCRIPTION
In Mobile view, the Activity stream gets sometimes an horizontal overflow when having multiple comment in an activity.
This fix, will change the fixed width `100%` added to `Show more comments` link.