### PR TITLE
MAINT-27751: Fix css style of portal left menu titles in gamification pages.

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/commons/skin/DocumentSelector/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/commons/skin/DocumentSelector/Style.less
@@ -101,7 +101,11 @@
 }
 
 
-  body {padding:0;margin:0;}
+body {
+  padding:0;
+  margin:0;
+  font-family: Helvetica, arial, sans-serif!important;
+}
 .BrowseLink  {
   text-decoration: none;
   border: 1px solid transparent;


### PR DESCRIPTION
The issue is: When going in gamification rules menu, a css is applied to portal left menu : all entries are in bold.
After digging in this issue i noticed that there is a conflict between Bootstrap and Vuetify's body font-family, so i made sure to apply the right font-family.
