### PR TITLE
MAINT-26764: Reaction labels (Reply and kudos) not colored in blue in comment section

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -1705,7 +1705,7 @@
           color: @primaryColor;
         }
         .CommentLabel {
-          color: var(--allPagesPrimaryColor, #578dc9);
+          color: @primaryColor;
         }
       }
     }

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -1432,7 +1432,7 @@
   }
   .statusAction {
     .SendKudosButtonTemplate {
-	  cursor: pointer;
+      cursor: pointer;
       .kudosLabel {
         color: @baseColorLight;
         font-size: 12px;
@@ -1758,7 +1758,7 @@
                       color: @baseColorLight;
                       font-size: 12px;
                       letter-spacing: 0!important;
-					  &:hover {
+                      &:hover {
                         color: @primaryColor;
                       }
                     }

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -1432,6 +1432,7 @@
   }
   .statusAction {
     .SendKudosButtonTemplate {
+	  cursor: pointer;
       .kudosLabel {
         color: @baseColorLight;
         font-size: 12px;
@@ -1700,6 +1701,12 @@
         .reactionLabel {
           font-size: 13px;
         }
+        .hasKudos {
+          color: @primaryColor;
+        }
+        .CommentLabel {
+          color: var(--allPagesPrimaryColor, #578dc9);
+        }
       }
     }
     .commentBox {
@@ -1751,6 +1758,9 @@
                       color: @baseColorLight;
                       font-size: 12px;
                       letter-spacing: 0!important;
+					  &:hover {
+                        color: @primaryColor;
+                      }
                     }
                     .lightGrey {
                       color: @baseColorLight;


### PR DESCRIPTION
- The kudos label on an activity or a comment should be blue colored on hover or when at least I sent a kudo to it
- The comment label should be always blue colored