### PR TITLE
MAINT-26764: Reaction labels (Reply and kudos) not colored in blue in comment section

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -1432,6 +1432,7 @@
   }
   .statusAction {
     .SendKudosButtonTemplate {
+      cursor: pointer;
       .kudosLabel {
         color: @baseColorLight;
         font-size: 12px;
@@ -1700,6 +1701,12 @@
         .reactionLabel {
           font-size: 13px;
         }
+        .hasKudos {
+          color: @primaryColor;
+        }
+        .CommentLabel {
+          color: @primaryColor;
+        }
       }
     }
     .commentBox {
@@ -1751,6 +1758,9 @@
                       color: @baseColorLight;
                       font-size: 12px;
                       letter-spacing: 0!important;
+                      &:hover {
+                        color: @primaryColor;
+                      }
                     }
                     .lightGrey {
                       color: @baseColorLight;


### PR DESCRIPTION
Backport [commit](https://github.com/Meeds-io/platform-ui/commit/5b39101765d7ff5c8838e5aaa76d82750c7ff939)