### PR TITLE
MAINT-35823 : Define a font-display strategy when loading fonts

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/_global.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/_global.less
@@ -25,6 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     url('@{font-path}/PLF-FONT-ICONS.svg?-m9uidt#PLF-FONT-ICONS') format('svg');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -36,6 +37,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   url('@{font-path}/Ionic/ionicons.svg') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 // COMMONS STYLESHEET

--- a/platform-ui-skin/src/main/webapp/skin/less/commons/skin/DocumentSelector/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/commons/skin/DocumentSelector/Style.less
@@ -24,6 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     url('@{font-path}/PLF-FONT-ICONS.svg?-m9uidt#PLF-FONT-ICONS') format('svg');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 // IMPORTANT to set the font
 .BrowseLink [class^="uiIcon"] {

--- a/platform-ui-skin/src/main/webapp/skin/less/component/Vote/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/component/Vote/Style.less
@@ -24,6 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     url('@{font-path}/PLF-FONT-ICONS.svg?-m9uidt#PLF-FONT-ICONS') format('svg');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 // IMPORTANT to set the font
 [class^="voted"], [class^="unvoted"] {

--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/welcome-screens/unlockTrial.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/welcome-screens/unlockTrial.less
@@ -28,6 +28,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     url('@{font-path}/PLF-FONT-ICONS.svg?-m9uidt#PLF-FONT-ICONS') format('svg');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 body {

--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/fontawesome.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/fontawesome.less
@@ -4983,6 +4983,7 @@ to {
   font-weight: normal;
   src: url("@{font-path}/vuetify/fa-brands-400.eot");
   src: url("@{font-path}/vuetify/fa-brands-400.eot?#iefix") format("embedded-opentype"), url("@{font-path}/vuetify/fa-brands-400.woff2") format("woff2"), url("@{font-path}/vuetify/fa-brands-400.woff") format("woff"), url("@{font-path}/vuetify/fa-brands-400.ttf") format("truetype"), url("@{font-path}/vuetify/fa-brands-400.svg#fontawesome") format("svg");
+  font-display: swap;
 }
 
 .fab {
@@ -4995,7 +4996,8 @@ to {
   font-weight: 400;
   src: url("@{font-path}/vuetify/fa-regular-400.eot");
   src: url("@{font-path}/vuetify/fa-regular-400.eot?#iefix") format("embedded-opentype"), url("@{font-path}/vuetify/fa-regular-400.woff2") format("woff2"), url("@{font-path}/vuetify/fa-regular-400.woff") format("woff"),
-    url("@{font-path}/vuetify/fa-regular-400.ttf") format("truetype"), url("@{font-path}/vuetify/fa-regular-400.svg#fontawesome") format("svg")
+    url("@{font-path}/vuetify/fa-regular-400.ttf") format("truetype"), url("@{font-path}/vuetify/fa-regular-400.svg#fontawesome") format("svg");
+  font-display: swap;
 }
 
 .far {
@@ -5008,7 +5010,8 @@ to {
   font-weight: 900;
   src: url("@{font-path}/vuetify/fa-solid-900.eot");
   src: url("@{font-path}/vuetify/fa-solid-900.eot?#iefix") format("embedded-opentype"), url("@{font-path}/vuetify/fa-solid-900.woff2") format("woff2"), url("@{font-path}/vuetify/fa-solid-900.woff") format("woff"),
-    url("@{font-path}/vuetify/fa-solid-900.ttf") format("truetype"), url("@{font-path}/vuetify/fa-solid-900.svg#fontawesome") format("svg")
+    url("@{font-path}/vuetify/fa-solid-900.ttf") format("truetype"), url("@{font-path}/vuetify/fa-solid-900.svg#fontawesome") format("svg");
+  font-display: swap;
 }
 
 .fa, .far, .fas {

--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/materialdesign-icons.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/materialdesign-icons.less
@@ -20,6 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-style: normal;
   font-weight: 400;
   src: url("@{font-path}/vuetify/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2") format('woff2');
+  font-display: swap;
 }
 /* cyrillic-ext */
 @font-face {
@@ -28,6 +29,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fCRc4EsA.woff2") format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  font-display: swap;
 }
 /* cyrillic */
 @font-face {
@@ -36,6 +38,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fABc4EsA.woff2") format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  font-display: swap;
 }
 /* greek-ext */
 @font-face {
@@ -44,6 +47,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fCBc4EsA.woff2") format('woff2');
   unicode-range: U+1F00-1FFF;
+  font-display: swap;
 }
 /* greek */
 @font-face {
@@ -52,6 +56,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fBxc4EsA.woff2") format('woff2');
   unicode-range: U+0370-03FF;
+  font-display: swap;
 }
 /* vietnamese */
 @font-face {
@@ -60,6 +65,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fCxc4EsA.woff2") format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -68,6 +74,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fChc4EsA.woff2") format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -76,6 +83,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 300;
   src: local('Roboto Light'), local('Roboto-Light'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmSU5fBBc4.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-display: swap;
 }
 /* cyrillic-ext */
 @font-face {
@@ -84,6 +92,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu72xKOzY.woff2") format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  font-display: swap;
 }
 /* cyrillic */
 @font-face {
@@ -92,6 +101,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu5mxKOzY.woff2") format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  font-display: swap;
 }
 /* greek-ext */
 @font-face {
@@ -100,6 +110,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu7mxKOzY.woff2") format('woff2');
   unicode-range: U+1F00-1FFF;
+  font-display: swap;
 }
 /* greek */
 @font-face {
@@ -108,6 +119,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu4WxKOzY.woff2") format('woff2');
   unicode-range: U+0370-03FF;
+  font-display: swap;
 }
 /* vietnamese */
 @font-face {
@@ -116,6 +128,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu7WxKOzY.woff2") format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -124,6 +137,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu7GxKOzY.woff2") format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -132,6 +146,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 400;
   src: local('Roboto'), local('Roboto-Regular'), url("@{font-path}/vuetify/KFOmCnqEu92Fr1Mu4mxK.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-display: swap;
 }
 /* cyrillic-ext */
 @font-face {
@@ -140,6 +155,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fCRc4EsA.woff2") format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  font-display: swap;
 }
 /* cyrillic */
 @font-face {
@@ -148,6 +164,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fABc4EsA.woff2") format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  font-display: swap;
 }
 /* greek-ext */
 @font-face {
@@ -156,6 +173,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fCBc4EsA.woff2") format('woff2');
   unicode-range: U+1F00-1FFF;
+  font-display: swap;
 }
 /* greek */
 @font-face {
@@ -164,6 +182,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fBxc4EsA.woff2") format('woff2');
   unicode-range: U+0370-03FF;
+  font-display: swap;
 }
 /* vietnamese */
 @font-face {
@@ -172,6 +191,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fCxc4EsA.woff2") format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -180,6 +200,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fChc4EsA.woff2") format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -188,6 +209,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 500;
   src: local('Roboto Medium'), local('Roboto-Medium'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmEU9fBBc4.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-display: swap;
 }
 /* cyrillic-ext */
 @font-face {
@@ -196,6 +218,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfCRc4EsA.woff2") format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  font-display: swap;
 }
 /* cyrillic */
 @font-face {
@@ -204,6 +227,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfABc4EsA.woff2") format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+  font-display: swap;
 }
 /* greek-ext */
 @font-face {
@@ -212,6 +236,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfCBc4EsA.woff2") format('woff2');
   unicode-range: U+1F00-1FFF;
+  font-display: swap;
 }
 /* greek */
 @font-face {
@@ -220,6 +245,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfBxc4EsA.woff2") format('woff2');
   unicode-range: U+0370-03FF;
+  font-display: swap;
 }
 /* vietnamese */
 @font-face {
@@ -228,6 +254,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfCxc4EsA.woff2") format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+  font-display: swap;
 }
 /* latin-ext */
 @font-face {
@@ -236,6 +263,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfChc4EsA.woff2") format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  font-display: swap;
 }
 /* latin */
 @font-face {
@@ -244,6 +272,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   font-weight: 700;
   src: local('Roboto Bold'), local('Roboto-Bold'), url("@{font-path}/vuetify/KFOlCnqEu92Fr1MmWUlfBBc4.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  font-display: swap;
 }
 
 .material-icons {
@@ -269,6 +298,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   src: url("@{font-path}/vuetify/materialdesignicons-webfont.eot?#iefix&v=3.9.97") format("embedded-opentype"), url("@{font-path}/vuetify/materialdesignicons-webfont.woff2?v=3.9.97") format("woff2"), url("@{font-path}/vuetify/materialdesignicons-webfont.woff?v=3.9.97") format("woff"), url("@{font-path}/vuetify/materialdesignicons-webfont.ttf?v=3.9.97") format("truetype");
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 .mdi:before,


### PR DESCRIPTION
As [recommended](https://web.dev/font-display/), while the font is loading from server, the client has to ensure to display a replacement of the loaded fonts. Thus here we use the `swap` font-display for all defined fonts.