### PR TITLE
MAINT-35287: Fix display of manage spaces page after migration from version 5.x.x to 6.x.x.

### DIFF
--- a/platform-ui-skin/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/platform-ui-skin/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -431,6 +431,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <css-path>/skin/css/social/portlets/uiSpacesAdministrationPortlet/Style.css</css-path>
     <css-priority>1</css-priority>
   </portlet-skin>
+  
+  <portlet-skin>
+    <application-name>social-vue-portlet</application-name>
+    <portlet-name>SpacesAdministration</portlet-name>
+    <skin-name>${exo.skin.name}</skin-name>
+    <css-path>/skin/css/social/portlets/uiSpacesAdministrationPortlet/Style.css</css-path>
+    <css-priority>1</css-priority>
+  </portlet-skin>
 
   <portlet-skin>
     <application-name>social-portlet</application-name>


### PR DESCRIPTION
Add portlet skin social-vue-portlet to fix UI regression in spaces administration page.