### PR TITLE
Task-35860 Use CSS Class for hiddenable Widgets

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSuggestionsPortlet/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSuggestionsPortlet/Style.less
@@ -22,7 +22,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
     .suggestions-wrapper {
         border-radius: 0px !important;
-        margin-bottom: 22px !important;
 
         .suggestions-title {
                 color: @greyColorLighten1;

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/SocialPage/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/SocialPage/Style.less
@@ -29,7 +29,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   }
 
   .v-application {
-    margin-bottom: 22px;
+    &:not(.hiddenable-widget) {
+      margin-bottom: 22px;
+    }
+    &.hiddenable-widget > .v-application--wrap > div {
+      margin-bottom: 22px;
+    }
   }
 
   .UIMobileSwipeParentContainer {

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/StreamPage/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/StreamPage/Style.less
@@ -40,8 +40,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           max-width: 320px;
           padding-left: 10px;
           box-sizing: border-box;
+
           .v-application {
-            margin-bottom: 20px;
+            &:not(.hiddenable-widget) {
+              margin-bottom: 20px;
+            }
+            &.hiddenable-widget > .v-application--wrap > div {
+              margin-bottom: 20px;
+            }
           }
 
            /* Added for sticky container */


### PR DESCRIPTION
Use CSS Class for hiddenable Widgets to hide completely application when it doesn't have content