### PR TITLE
Fix Identity Suggester listing style

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/CommonComponents/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/CommonComponents/Style.less
@@ -21,6 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     border-radius: 5px;
     padding: 0 !important;
     margin: 12px 0 !important;
+    white-space: normal;
   
     .v-input__slot {
       align-items: start !important;


### PR DESCRIPTION
When displaying list of identity suggesters, it should wrap to return to a new line when not having enough space to display all suggested users