### PR TITLE
MAINT-43803:Fix Profile Card issue on Safari

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/ProfileCard/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/ProfileCard/Style.less
@@ -110,6 +110,10 @@
 }
 .peopleCardFront, .peopleCardBack {
   backface-visibility: hidden;
+  /* Firefox */
+  -moz-backface-visibility: hidden;
+  /* Safari and Chrome */
+  -webkit-backface-visibility: hidden;
   position: absolute;
   top: 0;
   left: 0 ~'; /** orientation=lt */ ';

--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/ProfileCard/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/ProfileCard/Style.less
@@ -110,9 +110,7 @@
 }
 .peopleCardFront, .peopleCardBack {
   backface-visibility: hidden;
-  /* Firefox */
-  -moz-backface-visibility: hidden;
-  /* Safari and Chrome */
+  /* Safari */
   -webkit-backface-visibility: hidden;
   position: absolute;
   top: 0;


### PR DESCRIPTION
In order to assure that profile card css rules are adapted to supported safari browser, I added vendor-prefixed property for the relevant rendering engine : 
-webkit  Safari