### PR TITLE
TASK-43200 Delete blink effect when switching between space pages

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
@@ -116,6 +116,9 @@ body {
 #brandingTopBar {
   .logoContainer {
     position: relative;
+    min-width: 30px;
+    width: auto;
+    box-sizing: content-box;
     img {
       max-width: 200px;
       max-height: 30px;


### PR DESCRIPTION
This modification is related to Meeds-io/gatein-portal#197

When switching from a page to another using InPage navigation feature, a blink effect is visible due to space avatar loading.
This modification will fix the minimum width of the avatar of the space to avoid the blink effect.