### PR TITLE
MAINT-43803:Fix Profile Card issue on Safari

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/ProfileCard/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/ProfileCard/Style.less
@@ -110,6 +110,8 @@
 }
 .peopleCardFront, .peopleCardBack {
   backface-visibility: hidden;
+  /* Safari */
+  -webkit-backface-visibility: hidden;
   position: absolute;
   top: 0;
   left: 0 ~'; /** orientation=lt */ ';


### PR DESCRIPTION
In order to assure that profile card css rules are adapted to supported safari browser, I added vendor-prefixed property for the relevant rendering engine : 
-webkit  Safari