### PR TITLE
 Maint-40460: Fix Logo displayed in front of login form in mobile view

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/extensions/login.less
@@ -55,6 +55,7 @@ body {
     text-align: center;
     padding: 6px;
 }
+
 .brandingImageContent {
     img.brandingImage {
         width: 150px;
@@ -72,6 +73,11 @@ input[type="checkbox"]{
     z-index: 100;
     height: 17px!important;
     margin-right: 10px;
+}
+@media (max-width:@maxMobileWidth ) {
+.brandingImageContent img.brandingImage {
+  display: none;
+  }  
 }
 .uiCheckbox > span {
     display: inline-block;


### PR DESCRIPTION
In mobile view, the logo in display on front of the login form which make it uncomfortable or in some particular screen resolutions impossible to login, so the proposed fix is to hide the logo when using Mobile

(cherry picked from commit fbc9616)