### PR TITLE
TASK-47881 Fix who Is Online Avatar Style

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/homepage/whoisonline.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/portlets/homepage/whoisonline.less
@@ -52,14 +52,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             list-style: none;
             .size(40px,30px);
             text-align: center;
-            img {
-                max-height : 36px;
-                max-width : 36px;
-                height : 36px;
-                width : 36px;
-                padding: 5px;
-                border-radius: 50%;
-            }
         }
 	}
 }


### PR DESCRIPTION
Prior to this change, the Who Is Online Application avatars aren't well displayed. This will delete the specific Who Is Online images properties to make it managed as other avatars by Vuetify v-avatar component.