### PR TITLE
TASK-47881 Fix Notification avatar proportions

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
@@ -241,6 +241,7 @@ body {
                     border-radius: 50%;
                     width: 45px !important;
                     height: 45px;
+                    object-fit: cover;
                   }
                 }
 


### PR DESCRIPTION
Prior to this change, even on 6.1.x, the notifications avatars doesn't define the same proportion as other users avatars.