### PR TITLE
TASK-48680: Fix Notification display when having multiline paragraph (#307)

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
@@ -267,6 +267,10 @@ body {
                         font-weight: bold;
                       }
 
+                      br {
+                        display: none;
+                      }
+
                       div, p {
                         margin-bottom: 8px;
                         font-size: 13px;


### PR DESCRIPTION
Prior to this change, when a user likes or comments an activity with multiple paragraphs, an ellipsis is displayed for the first line, but a second line is displayed just after. To ensure to not display another line after the ellipsis, this fix will ensure to hide <br/> elements in the displayed text in notifications so that the ellipsis is properly applied.

(cherry picked from commit 025d9d66fd25fd9a2be61a116afad9bff5c5df99)