### PR TITLE
Task-47414: Display space redactors list in space info portlet

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceInfosPortlet/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceInfosPortlet/Style.less
@@ -19,28 +19,30 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #spaceInfosApp {
   padding: 8px 15px 8px 15px;
-}
-#spaceInfosApp #spaceDescription {
-  padding-left: 0;
-  overflow-wrap: break-word;
-}
-#spaceInfosApp h5 {
-  font-weight: bold;
-  color: @globalLoadingBorder;
-  line-height: 20px;
-  margin: 0;
-}
-#spaceInfosApp #spaceManagersList h5 {
-  margin-bottom: 8px;
-}
-#spaceInfosApp #spaceManagersList .spaceManagerEntry img {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-}
-#spaceInfosApp #spaceManagersList .spaceManagerEntry {
-  margin: 8px 0px;
-}
-#spaceInfosApp #spaceManagers > li > a {
-  color: @textColor;
+  #spaceDescription {
+    padding-left: 0;
+    overflow-wrap: break-word;
+  }
+  h5 {
+    font-weight: bold;
+    color: @globalLoadingBorder;
+    line-height: 20px;
+    margin: 0;
+  }
+  #spaceManagersList, #spaceRedactorsList {
+    h5 {
+      margin-bottom: 8px;
+    }
+	.entry {
+      margin: 8px 0px;
+	  img {
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+      }
+    }
+  }
+  #spaceRedactors > li > a, #spaceManagers > li > a {
+    color: @textColor;
+  }
 }


### PR DESCRIPTION
Prior to this change, in space info portlet we display only space managers. With this PR, we will display also space redactors