### PR TITLE
TASK-48336 : Problems about indication(External) when hovering a mentioned external user in a comment

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/tiptip/tiptip.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/tiptip/tiptip.less
@@ -68,7 +68,7 @@
   }
 }
 .externalFlagClass{
-  color: @baseColorLight;
+  color: @baseColorLight !important;
   font-weight: normal;
 }
 .connectAction {


### PR DESCRIPTION
Before this fix , when mentioning an external user in a comment the indication external appears in blue color instead of grey color . This was fixed by applying the correct class and style to every mentioned user when processing the comment message .