### PR TITLE
49558 : Fix display of close Icon in Notification items

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/TopBar/Style.less
@@ -237,7 +237,7 @@ body {
 
               .media {
                 display: flex;
-                max-width: 97%;
+                max-width: 95%;
                 .avatarXSmall {
                   max-height: 45px;
                   max-width: 45px;


### PR DESCRIPTION
Close icons became small and it is hard to click on it. It moves under the notification instead of being placed on the top-left of it in some small device sizes
The fix make sure the size of the notification does not exceed the max allowed size and increases the size of the close icon (font-size) to 16px