### PR TITLE
changed v-dialog selector to v-footer 

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <parent>
         <artifactId>platform-ui</artifactId>
         <groupId>org.exoplatform.platform-ui</groupId>
-        <version>6.3.x-SNAPSHOT</version>
+        <version>6.3.x-maintenance-SNAPSHOT</version>
     </parent>
 
     <artifactId>skin-addon-packaging</artifactId>

--- a/platform-ui-skin/pom.xml
+++ b/platform-ui-skin/pom.xml
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <parent>
         <artifactId>platform-ui</artifactId>
         <groupId>org.exoplatform.platform-ui</groupId>
-        <version>6.3.x-SNAPSHOT</version>
+        <version>6.3.x-maintenance-SNAPSHOT</version>
     </parent>
 
     <artifactId>platform-ui-skin</artifactId>

--- a/platform-ui-skin/src/main/webapp/skin/less/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/helpers.less
@@ -252,7 +252,7 @@
     position: relative;
     flex: 1 auto;
     height: 20px;
-    width: 100%;
+    width:450px;
     direction:rtl;
     max-width: 100%;
     margin: auto;

--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceInfosPortlet/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceInfosPortlet/Style.less
@@ -19,6 +19,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #spaceInfosApp {
   padding: 8px 15px 8px 15px;
+  background-color: white;
+  border-color: white;
+
   #spaceDescription {
     padding-left: 0;
     overflow-wrap: break-word;

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/SpaceMenu/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/SpaceMenu/Style.less
@@ -24,7 +24,7 @@
 .hide-scroll .spaceButtomNavigation {
   visibility: hidden;
 }
-.VuetifyApp .v-application .v-dialog.spaceButtomNavigation {
+.VuetifyApp .v-application .v-footer.spaceButtomNavigation {
   position: fixed;
   bottom: 0;
   max-width: 100vw !important;

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </parent>
   <groupId>org.exoplatform.platform-ui</groupId>
   <artifactId>platform-ui</artifactId>
-  <version>6.3.x-SNAPSHOT</version>
+  <version>6.3.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: Platform-UI</name>
   <modules>
@@ -52,7 +52,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- **************************************** -->
     <!-- Dependencies versions                    -->
     <!-- **************************************** -->
-    <org.exoplatform.depmgt.version>20.x-SNAPSHOT</org.exoplatform.depmgt.version>
+    <org.exoplatform.depmgt.version>20.x-maintenance-SNAPSHOT</org.exoplatform.depmgt.version>
   
     <!-- Sonar properties -->
     <sonar.organization>meeds-io</sonar.organization>


### PR DESCRIPTION
ISSUE: TABS bar of space hide the footer of the drawer 

FIX: changed style selector from v-dialog ( previous Vue component) to v-footer (new Vue component), so that the same styles apply to the new component.