### PR TITLE
49308: Add Ellipsis for the blue chips on the settings page for responsive layout

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
@@ -550,5 +550,5 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 }
 
 .mobile-chip-ellipsis{
-	max-width: 140px;overflow: hidden;text-overflow: ellipsis;
+	max-width: 130px;overflow: hidden;text-overflow: ellipsis;
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
@@ -550,5 +550,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 }
 
 .mobile-chip-ellipsis{
-	max-width: 130px;overflow: hidden;text-overflow: ellipsis;
+  max-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
@@ -548,3 +548,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     align-items: center;
     justify-content: space-around;
 }
+
+.mobile-chip-ellipsis{
+	max-width: 140px;overflow: hidden;text-overflow: ellipsis;
+}


### PR DESCRIPTION
ISSUE: in the settings page we need to display the blue label chips with ellipsis for mobile web
FIX: added custom style that will be applied to these chips only when the application is opened on a mobile browser