### PR TITLE
50398: bug strange grey bar displayed in multiple places in mobile 

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -281,7 +281,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 @zindexStickyContainer:   var(--allPagesZindexStickyContainer, 1020);
 @zindexStickyContainerUnder:   var(--allPagesZindexStickyContainerUnde, 990);
 @zindexInnerModal:        var(--allPagesZindexInnerModal, 1030);
-@zindexDrawerParent:      var(--zindexDrawerParent, 1021);
+@zindexDrawerParent:      var(--zindexDrawerParent,auto);
 @zindexDrawer:            var(--allPagesZindexDrawer, 1035);
 @zindexTooltip:           var(--allPagesZindexTooltip, 1040);
 @zindexModalBackdrop:     var(--allPagesZindexModalBackdrop, 1040);


### PR DESCRIPTION
ISSUE: TASK#50398 comment and share drawers' headers in the space pages are invisible
FIX: changed zindex variable related to the css class for these headers