### PR TITLE
Task 50022 changed v-dialog selector to v-footer

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/SpaceMenu/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/SpaceMenu/Style.less
@@ -24,7 +24,7 @@
 .hide-scroll .spaceButtomNavigation {
   visibility: hidden;
 }
-.VuetifyApp .v-application .v-dialog.spaceButtomNavigation {
+.VuetifyApp .v-application .v-footer.spaceButtomNavigation {
   position: fixed;
   bottom: 0;
   max-width: 100vw !important;


### PR DESCRIPTION
ISSUE: TABS bar of space hide the footer of the drawer
FIX: changed style selector from v-dialog ( previous Vue component) to v-footer (new Vue component), so that the same styles apply to the new component.
(cherry picked from commit 882c9e84d1e6b408f736ac12e260eb1d13cbd5d1)