### PR TITLE
QWIN-28439: Assign the default primary color for all links (#347)

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -73,7 +73,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
 
     a {
-      color: @primaryColor;
+      color: @primaryColorDefault;
     }
 
     p {


### PR DESCRIPTION
Assign the default primary color for all links without taking in consedration what was set in the branding