### PR TITLE
MAINT-51288: RTLize v-alert component content padding style (#349)

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -337,7 +337,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
 
     .v-alert__content{
-      padding-right: 50px;
+      padding-right: 50px ~'; /** orientation=lt */ ';
+      padding-left: 50px ~'; /** orientation=rt */ ';
     }
 
     .warning {


### PR DESCRIPTION
ISSUE: The padding style wasn't set to support RTL lang
FIX: RTLize the content style padding by adding a support RTL property