### PR TITLE
TASK-52300 : Display when the original space is hidden for non members (make links not clickable for hidden spaces)

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/helpers.less
@@ -186,6 +186,10 @@
 .not-clickable {
   cursor: default !important;
 }
+.not-clickable-link {
+  pointer-events: none;
+  cursor: default !important;
+}
 .not-allowed {
   cursor: not-allowed !important;
 }


### PR DESCRIPTION
Before these changes , when sharing an activity in the activity stream , the originial Activity space name and log is always displayed even if the current user is not a member of that space . so i added the necessary implementation in order to check the membership of the user in the space of a shared Activity.

