### PR TITLE
Task-51258: Default applications’s icons customization

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/component/Sprites/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/component/Sprites/Style.less
@@ -3599,8 +3599,16 @@ a:hover [class^="uiIconApp"], [class^="uiIconApp"]:hover,
 }
 
 .uiIconAppCalendarPortlet:before,
-.uiIconAppAgenda,.uiIconAppCalendar:before,.uiIconAppCalendarGadget:before {
+.uiIconAppAgenda:before,.uiIconAppCalendar:before,.uiIconAppCalendarGadget:before {
 		content: "\e68c";
+}
+
+.uiIconAppTasksManagement:before,.uiIconApptasks:before{
+	content: "\e611";
+}
+
+.uiIconAppnotes:before,.uiIconAppNotes:before{
+	content: "\e631";
 }
 
 .uiIconAppAnswersPortlet:before {


### PR DESCRIPTION
Problem: the icons for default applications are not customized and Tasks, Agenda and notes applications have the same icon
Fix: The icons for default applications such as Tasks, Agenda and notes are fixed and customized