### PR TITLE
Task-49268: text area components are no longer extensible

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/skin/enterprise.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/skin/enterprise.less
@@ -927,6 +927,7 @@ input[disabled],
   box-shadow: none;
   max-height: 115px;
   text-overflow: ellipsis;
+  width: 95%;
 }
 .selectize-control .selectize-input.focus {
   border-color: @inputFocusBorder;


### PR DESCRIPTION
Problem: in CMS setting and backoffice, text areas in web contents and list templates aren't extensible in term of hight
Fix: text areas in web contents and list templates are extensible in term of hight