### PR TITLE
Fix Meeds-io/wallet#181 : Enhance display of big wallet balances

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/StreamPage/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/StreamPage/Style.less
@@ -73,12 +73,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
                     #PerkstoreWidgetContainer {
                       flex: 1 1 50%;
+                      max-width: 50%;
                       box-sizing: border-box;
                       padding-right: 5px ~'; /** orientation=lt */ ';
                       padding-left: 5px ~'; /** orientation=rt */ ';
                     }
                     #WalletWidgetContainer {
                       flex: 1 1 50%;
+                      max-width: 50%;
                       box-sizing: border-box;
                       padding-left: 5px ~'; /** orientation=lt */ ';
                       padding-right: 5px ~'; /** orientation=rt */ ';


### PR DESCRIPTION
Prior to this change, big amounts are displayed in two lines instead of one single line. This change fixes https://github.com/Meeds-io/wallet/issues/181 by introducing a max-width style on Parent element of Wallent Balance application to allow displaying ellipsis.