### PR TITLE
TASK-54060: Fix default border style of textarea 

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -81,7 +81,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
 
     textarea {
-      border: Solid 1px @greyColor !important;
+      border: 1px solid @greyColor;
       max-width: 100%;
       padding: 3px 10px;
     }


### PR DESCRIPTION
ISSUE: when add a required directive to a textarea, the red border is bad displayed with unwanted box-shadow because of wrong style and the importnat flag that prevents its change on focus
FIX: This PR should correct the default border style and remove the uneeded important flag