### PR TITLE
TASK-56851: add text truncate class style in the uiSpaceAccessPortlet styles

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceAccessPortlet/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceAccessPortlet/Style.less
@@ -34,6 +34,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 			padding: 10px 0 25px;
 			color: @baseColorMedium;
 		}
+
+		.text-truncate {
+			white-space: nowrap !important;
+			overflow: hidden !important;
+			text-overflow: ellipsis !important;
+		}
 	}
 	
 	.alert-success {


### PR DESCRIPTION
Prior to this change, no dedicated style was exist to truncate the space name when its' very long in the space access portlet.
This Pr should add the text-truncate class to use it inside the portet ui template