### PR TITLE
Task-56970: Fix snackbar position in mobile version when space footer is dispalyed

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -542,5 +542,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       max-height: 100vh;
       margin: 0;
     }
+
+    .v-snack {
+      z-index: @zindexModal!important;
+    }
   }
 }


### PR DESCRIPTION
Before this fix on mobile version the snackbar is displayed under the footer space menu,
In this Fix, we add z-index higher than the z-index of the space menu to the snackbar component.