### PR TITLE
Task-57307: Fix height for user popover

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/popover/popover.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/popover/popover.less
@@ -40,6 +40,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         font-size: 19px!important;
         height: 18px;
         width: 18px;
+        padding-left: 0!important;
       }
     }
   }
@@ -53,4 +54,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   p {
     max-width: inherit !important;
   }
+}
+.profile-popover-menu {
+  height: 160px!important;
+  box-shadow: none!important;
 }


### PR DESCRIPTION
Before this fix, when we activate webRTC, the user's popover window is badly displayed with the drawdown call options.
With this fix, we adjust the CSS style of the user popover when the webRTC option is enabled.