### PR TITLE
TASK-56781 Delete embedded heigh of User Popover

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/popover/popover.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/popover/popover.less
@@ -56,6 +56,5 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   }
 }
 .profile-popover-menu {
-  height: 160px!important;
   box-shadow: none!important;
 }


### PR DESCRIPTION
Prior to this change, the user popover had a static heigh which can lead to a bad absolute position. This fix will simply delete the CSS height property on popover.