### PR TITLE
TASK-57941 Fix bad display of title in spaceInfos Portlet

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceInfosPortlet/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/portlets/uiSpaceInfosPortlet/Style.less
@@ -18,7 +18,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 @import "../../../mixins.less";
 
 #spaceInfosApp {
-  padding: 8px 15px 8px 15px;
+  padding: 8px 15px 8px 11px;
   background-color: white!important;
   border-color: white;
 


### PR DESCRIPTION
Problem: title not align vertically with the title of agenda timeline widget.
Fix: fix padding for this id selector `#spaceInfosApp`.