### PR TITLE
MEED-256: "New activities" information display and behavior

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/social.less
@@ -516,9 +516,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     width: 100%;
 }
 #SpacePageChildren .UITableColumn {
-  &, table, tbody, tr {
-    overflow: hidden;
-  }
   tbody tr td {
     max-width: 100%;
   }


### PR DESCRIPTION
Prior to this change, when a new activity is added to the space stream, the new activity information appears and if I scroll down, that information will be hidden by the top bar.
This is because the parent element has a "overflow: hidden"