### PR TITLE
feat: left menu review Display second panels (recent spaces / admin) - Desktop - MEED-609 - Meeds-io/meeds#16

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/HamburgerMenu/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/HamburgerMenu/Style.less
@@ -146,7 +146,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
   }
   .administrationTitle {
-   cursor: pointer;
    .uiAdministrationIcon {
      color: @toolbarLightIconColor;
      font-size: 22px;
@@ -239,8 +238,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 }
 
 .UserPageLink:hover .UserPageHome:before, .UserPageLinkHome .UserPageHome:before {
-  content: "\e6bf";
-  font-family: "PLF-FONT-ICONS";
+  content: "\e065";
 }
 
 .UserPageLink:hover .spaceThreeDotsMenu:before,


### PR DESCRIPTION
This change allow to remove the cursor pointer from the administration menu item in the left navigation, and edit the mark as home page menu icon.