### PR TITLE
feat: Left menu review Display second panels (recent spaces / admin)- Desktop - MEED-609 - Meeds-io/meeds#16

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/HamburgerMenu/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/HamburgerMenu/Style.less
@@ -140,8 +140,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     .v-list-item--active {
       color: white!important;
       background: @secondaryColor;
-      .v-list-item__icon i {
+      .v-list-item__icon {
+        i, span {
         color: @toolbarDarkLinkHoverColor !important;
+        }
       }
     }
   }


### PR DESCRIPTION
This change allows to edit the home icon in color to white, when a left navigation is selected as default page.