### PR TITLE
fix :Fix bad display in insert portal link window-EXO-58626

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/bootstrap/less/mixins.less
+++ b/platform-ui-skin/src/main/webapp/skin/bootstrap/less/mixins.less
@@ -658,11 +658,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       .clearfix();
       [class*="span"] {
         .input-block-level();
-        float: left ~'; /** orientation=lt */ ';
-        float: right ~'; /** orientation=rt */ ';
-        margin-left: @fluidGridGutterWidth ~'; /** orientation=lt */ ';
-        margin-right: @fluidGridGutterWidth ~'; /** orientation=rt */ ';
-        *margin-left: @fluidGridGutterWidth - (.5 / @gridRowWidth * 100 * 1%);
+        float: left ~'; /** orientation=rt */ ';
+        margin-right: 0 ~'; /** orientation=rt */ ';
       }
       [class*="span"]:first-child {
         margin-left: 0 ~'; /** orientation=lt */ ';


### PR DESCRIPTION
prior this change in web content administration when admin want to get a portal link the folder explorer component is displayed on upper right of the insert portal link window 
after this change the folder explorer display component be at the left side aligned to the content display component.