### PR TITLE
Fix: During page load, the text remains visible - EXO-60466 - Meeds-io/meeds-414

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/materialdesign-icons.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/materialdesign-icons.less
@@ -46,6 +46,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   src: url("@{font-path}/vuetify/materialdesignicons-webfont.eot?#iefix&v=5.9.55") format("embedded-opentype"), url("@{font-path}/vuetify/materialdesignicons-webfont.woff2?v=5.9.55") format("woff2"), url("@{font-path}/vuetify/materialdesignicons-webfont.woff?v=5.9.55") format("woff"), url("@{font-path}/vuetify/materialdesignicons-webfont.ttf?v=5.9.55") format("truetype");
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 .mdi:before,


### PR DESCRIPTION
Prior to this change, the lighthouse displays this problem (During the webfont load, text is not visible) .After that change, there is no such problem.