### PR TITLE
feat: Unread activities information Display unread activities in the stream - MEED-704- Meeds-io/MIPs#17

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/social/skin/Activity/Style.less
@@ -358,6 +358,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   }
 }
 
+.unread-activity {
+  .unread-activity-badge {
+    width: 14px;
+    height: 14px;
+    background: @errorColor;
+    border-radius: 100%;
+    border: 3px solid white;
+    top: -8px;
+    right: -8px;
+  }
+}
+
 @media (max-width: 480px) {
   .uiComposer .blastContainer {
     .share-buttons-down {


### PR DESCRIPTION
This PR allows to add a red badge to the top right side of an activity in the stream if this activity is net yet read.