### PR TITLE
fix: Fix Default Colors defined in Meeds Package - MEED-1716

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -31,7 +31,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 @baseBackgroundDark: var(--allPagesBaseBackgroundDark, darken(@baseBackgroundDefault, 10%));
 
 // Primary Color
-@primaryColorDefault: #476A9C;
+@primaryColorDefault: #3f8487;
 @primaryColor: var(--allPagesPrimaryColor, @primaryColorDefault);
 @primaryColorLight: var(--allPagesPrimaryColorLight, lighten(@primaryColorDefault, 10%));
 @primaryDarkColorGradientEnd: var(--allPagesPrimaryDarkColorGradientEnd, darken(@primaryColorDefault, 5%));
@@ -46,11 +46,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 @disabledBackgroundButton: var(--allPagesDisabledBackgroundButton, @disabledBackgroundButtonDefault);
 
 // Secondary Color
-@secondaryColorDefault: #476a9c;
+@secondaryColorDefault: #e25d5d;
 @secondaryColor: var(--allPagesSecondaryColor, @secondaryColorDefault);
 @secondaryColorDarken1: darken(@secondaryColorDefault, 15%);;
 
-@tertiaryColorDefault: #476A9C;
+@tertiaryColorDefault: #e25d5d;
 @tertiaryColor: var(--allPagesTertiaryColor, @tertiaryColorDefault);
 
 // Icon color
@@ -75,7 +75,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 @darkBlue: var(--allPagesDarkBlue, #295f9b);
 @greyColorDefault: #e1e8ee;
 @greyColor: var(--allPagesGreyColor, @greyColorDefault);
-@greyColorLighten1Default: #5f708a;
+@greyColorLighten1Default: #707070;
 @greyColorLighten1: var(--allPagesGreyColorLighten1, @greyColorLighten1Default);
 @greyColorLighten1Opacity1: var(--allPagesGreyColorLighten1Opacity1, fade(@greyColorLighten1Default, 13%));
 @greyColorLighten1Opacity2: var(--allPagesGreyColorLighten1Opacity2, fade(@greyColorLighten1Default, 8%));
@@ -140,7 +140,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 @bodyBackground: @baseBackground;
 @sidebarBackground: @secondaryColor;
 @contentBackground:  @baseBackground  url("@{images-path}/ShareImages/Background/texture.png") repeat left top;
-@textColorDefault: #333333;
+@textColorDefault: #20282c;
 @textColor: var(--allPagesBaseTextColor, @textColorDefault);       // #333333
 @textMediumColor: @baseColorMedium;           // #808080
 @textLightColor: @baseColorLight;       // #707070


### PR DESCRIPTION
Prior to this change, the default colors of Meeds were altered with old values. This change will allow to reuse variables.less in addons outside Meeds Package with the correct default branding colors of Meeds.