### PR TITLE
fix: Fix Display of Tick Icon in Tasks notification - MEED-1944

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/components/Icons/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/components/Icons/Style.less
@@ -242,9 +242,11 @@
   }
 }
 .uiIconTick:before {
+  &:extend(.fa);
   &:extend(.fa-check:before);
 }
 .uiIconComment:before {
+  &:extend(.fa);
   &:extend(.fa-comment:before);
 }
 .uiIconThumbUp:before {

--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -284,7 +284,7 @@
 .align-top {
   text-align: top;
 }
-.align-center {
+.align-center, .center {
   text-align: center;
 }
 .align-bottom {


### PR DESCRIPTION
This change will fix the display of Tick and comment icons display in Drawer.
at the same time, this will add a missing CSS class heleper `.center`.