### PR TITLE
fix: Document warning snack bar during document upload conflict is not in the foreground - EXO-62942 -  Meeds-io/meeds#810

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
@@ -27428,7 +27428,7 @@ html.overflow-y-hidden {
 .v-snack--absolute {
   height: 100%;
   position: absolute;
-  z-index: 1;
+  z-index: 1000;
 }
 .v-snack--centered {
   align-items: center;


### PR DESCRIPTION
After this fix, the snack bar will be displayed in the foreground in front of the grey overlay by changing the value of the z-index property.