### PR TITLE
fix: Fix Bottom Bar Display on chrome for Mobile - MEED-2187 - Meeds-io/meeds#949

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
@@ -173,6 +173,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     display: block;
   }
 
+  #ParentSiteContainer {
+    #ParentSiteRightContainer {
+      #ParentSiteContainerChildren {
+        position: fixed;
+      }
+    }
+  }
+
   #brandingTopBar {
     .logoContainer {
       &:after {


### PR DESCRIPTION
Prior to this change, when displaying builders on Mobile, the bottom of the page isn't displayed (Load More buttons, by example). This is due to a limitation of ViewPort definition in Mobile as described in https://developer.chrome.com/blog/url-bar-resizing/. This change will change the display of Pages using 'position: fixed' instead of 'position: absolute' in Mobile View.