### PR TITLE
fix: Remove additional Border on Text Fields added by browser style - MEED-1629 - Meeds-io/MIPs#49

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -318,6 +318,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     .v-text-field .v-input__prepend-inner {
       margin: auto;
     }
+    .v-text-field--outlined fieldset {
+      margin-left: 0;
+      margin-right: 0;
+    }
     .v-stepper {
       box-shadow: none;
 


### PR DESCRIPTION
Prior to this change, the `fieldset` HTML element has a predefined x-margins. This change will delete those margins on outlined Text fields to ensure to have the inputs aligned with other form elements inside a drawer.