### PR TITLE
fix: Fix Rich Editor Numbered List display - MEED-2337 - Meeds-io/meeds#1027

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -661,10 +661,8 @@
     padding: 0 !important;
     li {
       list-style-position: inside;
+      list-style-type: auto;
     }
-  }
-  ul li {
-    list-style-type: disc;
   }
   blockquote {
     margin: 20px 0 7px 20px ~'; /** orientation=lt */ ';


### PR DESCRIPTION
Prior to this change, the numbered list wasn't displayed using CSS Class Helper of Rich Editor content display. this change will make sure to display the original style of numbered list and bullets.