### PR TITLE
fix: date picker is hidden on Analytics page - EXO-65430 - Meeds-io/meeds#1024

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/platform/skin/uiSimpleContainers/simpleColumnContainer.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/platform/skin/uiSimpleContainers/simpleColumnContainer.less
@@ -1,6 +1,5 @@
 .UIContainer.SimpleColumnContainer {
   width: 100%;
-  overflow: hidden !important;
 }
 @media (max-width: 979px) {
   .UIContainer.SimpleColumnContainer {


### PR DESCRIPTION
Before this fix, an unnecessary overflow rule was added to the column container that hide the date picker in Analytics page.
This fix removes simply that rule that should be added instead inside contained portlets if there is a need for it.
