### PR TITLE
fix: Add missing class for uiIconMiniArrowRight - MEED-2468 - Meeds-io/meeds#1088

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/components/Icons/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/components/Icons/Style.less
@@ -137,6 +137,10 @@
   &:extend(.fas);
   &:extend(.fa-angle-down:before);
 }
+.uiIconMiniArrowRight:before {
+  &:extend(.fas);
+  &:extend(.fa-angle-right:before);
+}
 .uiIconArrowLeftMini:before, .uiIconMiniArrowLeft:before, .uiIconArrowLeft:before, .uiIconPrevArrow:before {
   &:extend(.fas);
   &:extend(.fa-angle-left:before);


### PR DESCRIPTION
Add missing class `uiIconMiniArrowRight` that is used in upper projects.