### PR TITLE
fix: Fix Vuetify Based link Colors - MEED-2534 - Meeds-io/meeds#1102

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -581,7 +581,7 @@
   max-height: 36px;
   max-width: 36px;
 }
-.reset-style-box {
+.VuetifyApp .v-application .reset-style-box {
   div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, dl, dt, dd, ol,
     ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, figcaption, figure, footer, header, hgroup, menu, nav, section, summary,
     time, mark, audio, video {
@@ -617,6 +617,7 @@
     font-size: revert;
     vertical-align: revert;
     background: revert;
+    color: revert;
   }
 
   ins {
@@ -654,7 +655,10 @@
     vertical-align: revert;
   }
 }
-.rich-editor-content {
+.VuetifyApp .v-application .rich-editor-content {
+  a {
+    color: revert;
+  }
   ul, ol {
     margin: 0 0 10px 25px ~'; /** orientation=lt */ ';
     margin: 0 25px 10px 0 ~'; /** orientation=rt */ ';
@@ -663,6 +667,9 @@
       list-style-position: inside;
       list-style-type: auto;
     }
+  }
+  p {
+    margin: 0 0 @baseLineHeight / 2;
   }
   blockquote {
     margin: 20px 0 7px 20px ~'; /** orientation=lt */ ';
@@ -680,5 +687,8 @@
       font-style: italic;
       color: @textColor!important;
     }
+  }
+  .metadata-tag {
+    color: @primaryColor;
   }
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -70,7 +70,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
 
     a {
-      color: @primaryColorDefault;
+      color: @primaryColor;
     }
 
     p {


### PR DESCRIPTION
Prior to this change, the link colors of all Vuetify components were embedded using basic green color which is not brandable. This change will make the link colors brandable again and just define the default colors of all based Rich Editors contents.