### PR TITLE
fix: Fix Bullet Points Rich Editor Style - MEED-2553 - Meeds-io/meeds#1114

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -666,10 +666,6 @@
     margin: 0 0 10px 25px ~'; /** orientation=lt */ ';
     margin: 0 25px 10px 0 ~'; /** orientation=rt */ ';
     padding: 0 !important;
-    li {
-      list-style-position: inside;
-      list-style-type: auto;
-    }
   }
   p {
     margin: 0 0 @baseLineHeight / 2;


### PR DESCRIPTION
Prior to this change, the style property 'list-style-type: auto' wasn't applying the correct style on bullet points. This change ensures to let the style inherited from the upper class 'reset-style-box' which reverts to default browser style.