### PR TITLE
feat: Remove Vuetify Alert Component overridden style - MEED-2627 - Meeds-io/MIPs#99

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -109,6 +109,15 @@
 .error-color-background {
   background-color: @errorColor !important;
 }
+.success-color-background {
+  background-color: @successColor !important;
+}
+.info-color-background {
+  background-color: @infoColor !important;
+}
+.warning-color-background {
+  background-color: @warningColor !important;
+}
 .light-grey-background {
   background-color: @greyColorOpacity1 !important;
 }
@@ -498,6 +507,9 @@
   color: @mediumGrey !important;
 }
 
+.z-index-snackbar {
+  z-index: @zindexSnackBar!important;
+}
 .z-index-modal {
   z-index: @zindexModal!important;
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -292,7 +292,7 @@
 @zindexTooltip:           var(--allPagesZindexTooltip, 1040);
 @zindexModalBackdrop:     var(--allPagesZindexModalBackdrop, 1040);
 @zindexModal:             var(--allPagesZindexModal, 1050);
-
+@zindexSnackBar:          var(--allPagesZindexSnackbar, 1060);
 
 
 // Hr border color

--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -334,25 +334,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       margin-top: -23px;
     }
 
-    .v-alert:not(.position-static):not(.position-relative) {
-      position: fixed;
-      z-index: 1000;
-      bottom: 15px;
-      left: 35px;
-      box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12) !important;
-      border-left: 5px solid;
-    }
-
-    .v-alert__content{
-      padding-right: 50px ~'; /** orientation=lt */ ';
-      padding-left: 50px ~'; /** orientation=rt */ ';
-    }
-
-    .v-alert__icon.v-icon {
-      margin-top: auto;
-      margin-bottom: auto;
-    }
-
     .warning {
       background: @warningBackground !important;
       border-color: @warningBorder !important;
@@ -564,7 +545,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     }
 
     .v-snack {
-      z-index: @zindexModal!important;
+      z-index: @zindexSnackBar!important;
     }
   }
 }


### PR DESCRIPTION
Prior to this change, the style of v-alert Vuetify component was embedded by style. This change will delete the overridden style in favor of adding a centralized component in social which will define the Toast notification style.