### PR TITLE
feat: Make Site or Page Body scrollable switch topbar position - MEED-2789 - Meeds-io/MIPs#84

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
@@ -198,7 +198,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 /* ============= End - Shared Layout  ============= */
 
 /* ============= Site Layout - Display  ============= */
-#UISiteBody {
+.site-scroll-parent {
   position: relative;
   max-width: 100%;
   overflow: auto;
@@ -206,7 +206,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 }
 
 @media (min-width: @minTabletWidth) {
-  #UISiteBody {
+  .site-scroll-parent {
     .specific-scrollbar()
   }
 }


### PR DESCRIPTION
Prior to this change, only the site body was scrollable considering that TopBar can be positionned in Shared layout only. This change allows to add scroll behavior on PageBody if the Top Bar is defined in Site Layout instead of Shared Layout.