### PR TITLE
feat: Hide empty slider icons in Tabs - MEED-2846 - Meeds-io/MIPs#100

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -335,6 +335,10 @@
       margin-left: -23px;
       margin-top: -23px;
     }
+    .v-slide-group__next--disabled,
+    .v-slide-group__prev--disabled {
+      display: none;
+    }
 
     .warning {
       background: @warningBackground !important;


### PR DESCRIPTION
Prior to this change, when a Tab list overflows comparing to its parent container, the disabled arrow icon isn't displayed and a blank square is displayed instead. This change will hide the arrow container when not active.

![image](https://github.com/Meeds-io/platform-ui/assets/594824/e439bd32-d2e6-4f30-820d-205d099eea2e)
