### PR TITLE
fix: Fix color of Heading elements - MEED-3015 - Meeds-io/meeds#1335

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
@@ -278,12 +278,10 @@ h1, h2, h3, h4, h5, h6 {
   margin: (@baseLineHeight / 2) 0;
   font-family: @headingsFontFamily;
   font-weight: @headingsFontWeight;
-  color: @headingColor;
   text-rendering: optimizelegibility; // Fix the character spacing for headings
   small {
     font-weight: normal;
     line-height: 1;
-    color: @grayLight;
   }
 }
 


### PR DESCRIPTION
Prior to this change, when adding a content using CKEDitor, the heading elements uses a specific color, while it should be the default Text color.