### PR TITLE
fix: Add Class Helpers for padding and margin outside Vue apps - MEED-3023 - Meeds-io/meeds#1349

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -436,6 +436,12 @@
 .pt-2px {
   padding-top: 2px!important;
 }
+.pa-0 {
+  padding: 0px !important;
+}
+.ma-0 {
+  margin: 0px !important;
+}
 .hidden {
   display: none !important;
   visibility: hidden !important;


### PR DESCRIPTION
This change will introduce new CSS Class Helpers to be used outside of Vue applications in Page Layout to delete margins and paddings.