### PR TITLE
feat: Add CSS Helper for Left absolute position - MEED-3018 - Meeds-io/MIPs#108

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -421,6 +421,9 @@
 .r-0 {
   right: 0px!important;
 }
+.l-0 {
+  left: 0px!important;
+}
 
 .t-0 {
   top: 0px!important;


### PR DESCRIPTION
This change will add a CSS Class helper to be used to position absolutely an element to the left.