### PR TITLE
fix: Fix Container Style when applied twice - MEED-3024 - Meeds-io/meeds#1351

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
@@ -259,6 +259,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   box-sizing: border-box !important;
   padding: 24px 20px 0 !important;
   margin: 0 auto !important;
+
+  .singlePageApplication {
+    padding: 0 !important;
+    margin: 0 !important;
+  }
 }
 
 .SpaceActivityStreamPortletPage {


### PR DESCRIPTION
This change will avoid applying the margin twice when the CSS Class helper singlePageApplication is applied in container and on application. Applying it on application will ensure to always have the same Look and feel when adding it using a layout management. Addming it in a container will ensure to have the same ratio of page independing from the pplications added into it.