### PR TITLE
fix: Fix Container Style when applied twice - MEED-3024 - Meeds-io/meeds#1351 

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
@@ -259,6 +259,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   box-sizing: border-box !important;
   padding: 24px 20px 0 !important;
   margin: 0 auto !important;
+
+  .singlePageApplication {
+    padding: 0 !important;
+    margin: 0 !important;
+  }
 }
 
 .SpaceActivityStreamPortletPage {


### PR DESCRIPTION

This change will avoid applying the margin twice when the CSS Class helper singlePageApplication is applied in container and on application. Applying it on application will ensure to always have the same Look and feel when adding it using a layout management. Addming it in a container will ensure to have the same ratio of page independing from the pplications added into it.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
