### PR TITLE
fix: Fix Heading 3 color in editor of Notes app - EXO-68247

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
@@ -278,6 +278,7 @@ h1, h2, h3, h4, h5, h6 {
   margin: (@baseLineHeight / 2) 0;
   font-family: @headingsFontFamily;
   font-weight: @headingsFontWeight;
+  color: @headingColor !important;
   text-rendering: optimizelegibility; // Fix the character spacing for headings
   small {
     font-weight: normal;


### PR DESCRIPTION
Prior to this change, Heading 3 appeared in blue by default in the editor. After this change, Heading 3 now maintains consistent color with other titles.