### PR TITLE
feat: Add Header Text Color CSS Class Helper - MEED-3199 - Meeds-io/MIPs#106 (#734)

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -77,6 +77,9 @@
 .text-color {
   color: @textColor !important;
 }
+.header-color {
+  color: @headingColor !important;
+}
 .error-color {
   color: @errorColor !important;
 }


### PR DESCRIPTION
Add generic CSS Helper for heading color variable

- Resolves Meeds-io/MIPs#106