### PR TITLE
fix: in mobile toolbar not well displayed - EXO-67913 - Meeds-io/meeds#1682

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/Style.less
@@ -201,7 +201,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       display: none;
     }
     .brandingContainer.space {
-      max-width: 100px;
+      display: none;
     }
   }
 }


### PR DESCRIPTION
before this change, in mobile open any app of a space whose name contains 30 char or more
the toolbar is not well displayed and some buttons are hidden
After this change, the space  name is hidden for mobile devices same way for the company logo 