### PR TITLE
feat: Add Vuetify Border Color in Branding - MEED-3409 - Meeds-io/MIPs#120

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -150,6 +150,12 @@
 .border-color-grey-lighten {
   border: 1px solid @greyColorLighten1 !important;
 }
+.border-color-thin-grey-opacity1 {
+  border: thin solid @greyColorOpacity1 !important;
+}
+.border-color-thin-grey-opacity2 {
+  border: thin solid @greyColorOpacity2 !important;
+}
 .border-color {
   border: 1px solid @btnBorder !important;
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -76,6 +76,7 @@
 @greyColorLighten1Opacity1: var(--allPagesGreyColorLighten1Opacity1, fade(@greyColorLighten1Default, 13%));
 @greyColorLighten1Opacity2: var(--allPagesGreyColorLighten1Opacity2, fade(@greyColorLighten1Default, 8%));
 @greyColorOpacity1: var(--allPagesGreyColorOpacity1, fade(@greyColorDefault, 35%));
+@greyColorOpacity2: var(--allPagesGreyColorOpacity2, fade(@baseColorDefault, 12%));
 
 @whiteColorDefault: #ffffff;
 @lightWhite: var(--allPagesLightWhite, @whiteColorDefault);


### PR DESCRIPTION
This change will add default Vuetify cards border color in branding to allow using it outside cards.