### PR TITLE
fix: Fix CSS priority on Disabled Tab arrows - MEED-3873 - Meeds-io/meeds#1644

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -337,7 +337,7 @@
     }
     .v-slide-group__next--disabled,
     .v-slide-group__prev--disabled {
-      display: none;
+      display: none !important;
     }
 
     .warning {


### PR DESCRIPTION
Prior to this change, the Disabled Tabs arrows buttons was displayed with empty icons (blank space). This change ensures to hide effectively those blank spaces which wasn't applied everywhere due to CSS priority in Vuetify which is more than the classes definition overridden in `vuetify-all.less`.