### PR TITLE
fix: Fix box-sizing of layout - MEED-6806 - Meeds-io/meeds#1966

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -262,14 +262,22 @@
 #singlePageApplicationContainer, .singlePageApplication, #SpacePage, #StreamPage, .SpaceActivityStreamPortletPage, #parentSocialPage {
   max-width: 100% !important;
   width: @singlePageApplicationWidth !important;
-  box-sizing: border-box !important;
   padding: 24px 20px 0 !important;
   margin: 0 auto !important;
+
+  /* Start: box-sizing inheritence fix: Important to not influence original box-sizing inherited in child contents */
+  box-sizing: border-box !important;
+  > * {
+    /* Set back to default CSS value: content-box */
+    box-sizing: content-box !important;
+  }
+  /* End: box-sizing inheritence fix */
 
   .singlePageApplication {
     padding: 0 !important;
     margin: 0 !important;
   }
+
 }
 
 .SpaceActivityStreamPortletPage {


### PR DESCRIPTION
Prior to this change, the 'box-sizing' of Portlets added in new layout uses 'border-box' whereas the default value has to be used instead to not influence portlets display switch used layout version (New with sections VS old with containers).