### PR TITLE
fix: Fix Overlay and Dialog display when drawer opened - MEED-6825 - Meeds-io/meeds#1988

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -654,6 +654,9 @@
 .z-index-snackbar {
   z-index: @zindexSnackBar!important;
 }
+.z-index-modal-overlay {
+  z-index: @zindexModalBackdrop!important;
+}
 .z-index-modal {
   z-index: @zindexModal!important;
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -180,6 +180,15 @@
   display: none;
 }
 
+#vuetify-apps {
+  .v-overlay--active {
+    z-index: @zindexModalBackdrop !important;
+  }
+  .v-dialog__content--active {
+    z-index: @zindexModal !important;
+  }
+}
+
 @media (max-width: @maxMobileWidth) {
   .mobile-visible {
     display: block;


### PR DESCRIPTION
Prior to this change, when the drawer is opened, the dialogs are displayed with a low z-index. This change fixes the dialogs z-index with its overlay to be over the drawer when both opened.

(Resolves Meeds-io/meeds#1988)