### PR TITLE
feat: Allow to add a min height on singlePageApplication pages - MEED-6920 - Meeds-io/MIPs#139

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -289,6 +289,10 @@
 
 }
 
+.singlePageApplication.no-applications-spacing {
+  min-height: ~"calc(100vh - @{topbarHeight} - @{applicationSpaceBottom})";
+}
+
 .SpaceActivityStreamPortletPage {
   #SpacePage, #StreamPage {
     padding: 0 !important;
@@ -300,6 +304,7 @@
 }
 
 @media (min-width: @minTabletWidth) {
+
   #parentSocialPage {
     .UIRowContainer:first-of-type {
       > #rightSocialPage, > .rightSocialPage {


### PR DESCRIPTION
Prior to this change, when having a single page application, the container height fits the application height which causes an issue when the portlet has a content (a menu by example) which overflows the portlet height. This change will add a possibility to specify a min-height on such pages for a better display.