### PR TITLE
fix: Fix display of portlets in sections in Mobile mode - MEED-7079 - Meeds-io/meeds#2183

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
@@ -132,10 +132,14 @@
     .PORTLET-FRAGMENT {
       margin-bottom: ~"var(--grid-layout-gap, 20px)";
     }
+
     .flex-cell {
       row-gap: 0;
       .layout-application {
         padding-bottom: 0 !important;
+      }
+      > :last-of-type .PORTLET-FRAGMENT {
+        margin-bottom: 0;
       }
     }
     .layout-section-mobile-pages {


### PR DESCRIPTION
Prior to this change, the padding on sections plus the margin on applications inside the section makes the spacing between applications very large. This change will delete the margin on the last application of a given section to let the padding of the section applied only.