### PR TITLE
fix: Allow to refresh page by pull gesture on Mobile - MEED-7328 - Meeds-io/meeds#2314

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
@@ -462,3 +462,9 @@ address {
 .btn.disabled, .btn[disabled] {
   opacity: .65;
 }
+
+@media (max-width: @maxTabletWidth) {
+  body {
+    overflow: auto;
+  }
+}


### PR DESCRIPTION
Prior to this change, the body overflow CSS style value wasn't allowing to use Mobile Browser builtin feature  gesture. This change will enable it by deleting the overflow hidden property value on Mobile and Tablet devices.