### PR TITLE
fix: Fix Text Input style when no type attribute - MEED-7469 - Meeds-io/MIPs#147

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/reset.less
@@ -116,6 +116,7 @@ input[type="search"]::-webkit-search-cancel-button {
 }
 select,
 textarea,
+input:not([type]),
 input[type="text"],
 input[type="password"],
 input[type="datetime"],
@@ -134,7 +135,6 @@ input[type="color"] {
   color: @inputColor;
   background-color: @inputBackground;
   border: 1px solid @inputBorder;
-  padding: 4px 6px;
   padding: 0 10px;
   margin-bottom: @baseLineHeight / 2;
   font-size: @inputFontSize;


### PR DESCRIPTION
Prior to this change when adding an input text without explicit type (= text input), the style of a text input isn't zpplied. This change will include the input without specific type to be considered as a text input style.