### PR TITLE
fix: Drop-down list for Group selection isn't displayed in site administration - EXO-73925 - Meeds-io/meeds#2388. (#828)

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/components/Mention/Style.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/components/Mention/Style.less
@@ -471,7 +471,7 @@ div.suggestions div.resultItem p {
 }
 .selectize-dropdown {
   position: absolute;
-  z-index: 10;
+  z-index: @zindexDropdown !important;
   border: 1px solid #d0d0d0;
   background: @baseBackground;
   margin: -1px 0 0 0;


### PR DESCRIPTION
Before this change, when open administration site and open Application center/spaces administration page or multifactor authentication or permissions site or permissions on page then type a group name, no Drop-down list for group suggestions is displayed. After this change, a drop-down list is displayed showing the groups respecting the searched words.

(cherry picked from commit 426e37d560c93378d4050565ba961995e41b9627)