### PR TITLE
fix: Fix Vuetify List Dense Style - MEED-7511 - Meeds-io/meeds#2406

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/README.txt
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/README.txt
@@ -27,3 +27,4 @@ Modifications applied on imported libraries:
   - Delete font-size on .v-tab
   - Change color to use @menuTextColor on .v-tab
   - Delete .v-card--link focus background to not have grey background once clicked
+  - Fix .v-list-item__title & .v-list-item__subtitle line-height in dense configuration

--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
@@ -20257,7 +20257,7 @@ html.overflow-y-hidden {
 .v-list-item--dense .v-list-item__subtitle,
 .v-list--dense .v-list-item .v-list-item__title,
 .v-list--dense .v-list-item .v-list-item__subtitle {
-  line-height: 1rem;
+  line-height: 1.1em;
 }
 .v-list-item--dense.v-list-item--two-line,
 .v-list--dense .v-list-item.v-list-item--two-line {


### PR DESCRIPTION
Prior to this change, after increasing the font-size in Meeds-io/MIPs#144, the predefined line-height of List, in dense configuration, isn't adapted and truncates the bottom of some latin characters. This change ensures to use element relative unit ('em' instead of 'rem') to make this more flexible and adds a small spacing in case of big used fonts.

Resolves Meeds-io/meeds#2406