### PR TITLE
fix: Fix Topbar Label Size - MEED-7543 - Meeds-io/meeds#273

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -156,8 +156,8 @@
       box-sizing: content-box;
       img {
         max-width: 200px;
-        max-height: 30px;
-        min-height: 30px;
+        max-height: 36px;
+        min-height: 36px;
       }
     }
     .brandingContainer {


### PR DESCRIPTION
Prior to this change, the topbar site label and logo was having a small size comparing to top bar buttons. This change allow to adjust the size of Topbar to be the same as other buttons.