### PR TITLE
feat: Allow to use reduced scroll height when horizontal scroll - MEED-8026 - Meeds-io/MIPs#170

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/mixins.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/mixins.less
@@ -28,6 +28,7 @@
     background-color: transparent;
     border-radius: 10px;
     width: 5px;
+    height: 5px;
   }
   &:hover {
     scrollbar-color: @greyColorLighten1;


### PR DESCRIPTION
Prior to this change, when using the `specific-scrollbar` class on an horizontal scrollbar, the height still the same defined by the OS + Browser. This change will use the same height of horizontal scrollbar as it 's used in vertical scrollbar width.