### PR TITLE
feat: Delete useless Topbar Loading Styling - MEED-8266 - Meeds-io/MIPs#175

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -141,16 +141,6 @@
         }
       }
     }
-
-    .TopbarLoadingContainerTDContainer {
-      display: block;
-      position: fixed;
-      top: 53px;
-      width: 100%;
-      height: 7px;
-      min-height: 7px;
-      max-height: 7px;
-    }
   }
 }
 

--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
@@ -162,9 +162,7 @@
   }
 
   .layout-banner-section {
-
-    .layout-section-content {
-      box-sizing: border-box;
+    &.layout-section-content, .layout-section-content {
       padding-top: var(--sectionMarginTop, 0);
       padding-right: var(--sectionMarginRight, 0);
       padding-bottom: var(--sectionMarginBottom, 0);


### PR DESCRIPTION
This change will delete the Topbar Loading styling knowing that it has been moved from Topbar Container definition to portal main page (UIPortalApplication).