### PR TITLE
feat: Delete margins in Topbar on Mobile - MEED-8426 - Meeds-io/meeds#2945

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -125,11 +125,14 @@
 
       &.menu-topNavigation-container {
         max-width: 70%;
-        margin: 0 15%;
+        margin: 0 auto;
         flex-grow: 1;
         flex-shrink: 1;
         overflow: hidden;
         justify-content: center;
+        > * {
+          max-width: ~"calc(100% - 40px)";
+        }
       }
     }
   }


### PR DESCRIPTION
Prior to this change, when using Mobile, the Topbar Menu is still displayed but absolutely in the bottom of the page, while the margins are still displayed in Parent DOM. This change will remove the margins from Parent DOM container and replace it by a spacing (same as Site Layout Editor Behavior).

Resolves Meeds-io/meeds#2945