### PR TITLE
fix: Missing background for links preview - MEED-8368 - Meeds-io/meeds#2942

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/mixins.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/mixins.less
@@ -80,7 +80,7 @@
   .v-data-table.theme--light,
   .v-input__slot,
   .cke_wysiwyg_frame {
-    background-color: transparent !important;
+    background-color: @drawerBackgroundColor;
   }
   .v-menu__content {
     color: @btnColor !important;


### PR DESCRIPTION
Prior to this change, the link preview background was incorrect due to the transparent background applied by the `drawer-layout class`. This change updates the background color property to use `drawerBackgroundColor`