### PR TITLE
fix: Fix Bottom Bar Color - MEED-8293 - Meeds-io/meeds#2940

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/globalLayout.less
@@ -86,7 +86,7 @@
 
 #UITopBarContainer {
   box-shadow: none;
-  border-bottom: 1px solid white;
+  border-bottom: 1px solid transparent;
   position: absolute;
   top: 0;
   width: 100%;


### PR DESCRIPTION
Prior to this change, when changing the Topbar color, a white border color was observed. This change hides the color of bottom border of Topbar by using a transparent color.

Resolves Meeds-io/meeds#2940