### PR TITLE
fix: Contrast background and surrounding text problems of some items - MEED-9011 - Meeds-io/meeds#2975

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -1104,7 +1104,7 @@
     }
   }
   a {
-    color: @linkColorUnvisited;
+    color: @blueLinkColor;
     &:hover, &:focus { 
       text-decoration: underline;
     } 

--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -195,9 +195,8 @@
 @linkColor:             @primaryColor;      // Special title, text, hover, press, hyper-link or selected link
 @linkColorHover:        @primaryColor;
 
-@linkColorUnvisited:    #0078C8;
-@linkColorVisited:      #C700C7;      
-@blueLinkColorDefault:  #0782C1;
+@linkColorVisited:      #C700C7;
+@blueLinkColorDefault:  #0078C8;
 @blueLinkColor:         var(--allPagesLinkBlueColor, @blueLinkColorDefault);
 
 


### PR DESCRIPTION
Before this change, when access to stream page, we need to find a color that respects the contrast ratio for both background and surrounding text and apply it on all these items. To fix this problem, change the colors of unvisited and visited and add underlined style to link hovered. After this change, unvisited link color has color #0078C8, visited link color has color #C700C7 and when hovering a link, it is underlined.
Resolves https://github.com/Meeds-io/meeds/issues/2975
