### PR TITLE
Fix: Contrast problem between text and background of tooltips - MEED-9090 - Meeds-io/meeds#2873

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -190,6 +190,11 @@
 
 @placeholderText:       rgba(0, 0, 0, 0.38);
 
+// Tooltip
+@tooltipBackgroundDefault:       transparent;
+@tooltipBackgroundColorDefault:  #707070;
+@tooltipBackgroundColor:         var(--allPagesTooltipBackgroundColor, @tooltipBackgroundColorDefault);
+
 // Links
 // -------------------------
 @linkColor:             @primaryColor;      // Special title, text, hover, press, hyper-link or selected link

--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -68,6 +68,8 @@
 
     .v-tooltip__content {
       z-index: @zindexTooltip !important;
+      background: @tooltipBackgroundDefault !important;
+      background-color: @tooltipBackgroundColor !important;
     }
 
     .v-btn--icon {


### PR DESCRIPTION
Before this change, when checking out the tooltips, the contrast ratio was set to 4.05. To fix this problem, change the background of the Vuetify component's tooltip to #707070 and the background to transparent. After this change, the contrast increases to 4.5.
Resolves https://github.com/Meeds-io/meeds/issues/2873
