### PR TITLE
fix: Standardization of focus indicators on interactive elements - MEED-9187 - Meeds-io/meeds#2918

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/vuetify-all.less
@@ -65,6 +65,24 @@
     .grid-list-md {
       box-sizing: border-box;
     }
+    
+    [class^="v-"]:focus:not(button[class^="v-icon"]),
+    [class^="v-"] *:focus:not(button[class^="v-icon"]),
+    [class*=" v-"]:focus:not(button[class^="v-icon"]),
+    [class*=" v-"] *:focus:not(button[class^="v-icon"]) {
+      box-shadow: 0 0 0 2px #000 inset;
+    }
+    
+    [class^="v-"]:focus:not(:active)::before,
+    [class^="v-"] *:focus:not(:active)::before,
+    [class*=" v-"]:focus:not(:active)::before,
+    [class*=" v-"] *:focus:not(:active)::before {
+      opacity: 0 !important;
+    }
+    
+    button[class^="v-icon"]:focus:not(:active)::before {
+      opacity: 1 !important;
+    }
 
     .v-tooltip__content {
       z-index: @zindexTooltip !important;
@@ -264,7 +282,7 @@
       text-shadow: none;
       box-shadow: none;
       font-weight: normal;
-      &:hover, &:focus {
+      &:hover {
         color: @btnColor !important;
       }
     }


### PR DESCRIPTION
Before this change, when enable the focus of left menu and top bar items by tabbing or by using pointing device, A lot of interactive elements on the platform currently have a focus style defined but not visible enough. To fix this problem, add a box-shadow style for vuetify elements when in focus. After this change, at the focus action the vuetify elements have the same style as the html elements.