### PR TITLE
fix: update input text border color to improve constrast - MEED-9784 - meeds-io/MIPs#203

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/vuetify/lib/vuetify.less
@@ -18498,13 +18498,13 @@ html.overflow-y-hidden {
   color: rgba(255, 255, 255, 0.7);
 }
 .theme--light.v-text-field--outlined:not(.v-input--is-focused):not(.v-input--has-state) > .v-input__control > .v-input__slot fieldset {
-  color: rgba(0, 0, 0, 0.38);
+  color: @greyColorLighten1;
 }
 .theme--light.v-text-field--outlined:not(.v-input--is-focused):not(.v-input--has-state):not(.v-input--is-disabled) > .v-input__control > .v-input__slot:hover fieldset {
-  color: rgba(0, 0, 0, 0.86);
+  color: @greyColorLighten1;
 }
 .theme--light.v-text-field--outlined:not(.v-input--is-focused).v-input--is-disabled > .v-input__control > .v-input__slot fieldset {
-  color: rgba(0, 0, 0, 0.26);
+  color: @greyColorLighten1;
 }
 
 .theme--dark.v-text-field > .v-input__control > .v-input__slot:before {


### PR DESCRIPTION
Before this fix, the border color for text input was too low in constrast. This commit update the color to greyColorLighten1 (#707070) in order to improve this contrast

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
