### PR TITLE
fix: Information loss after a zoom in of 200% - MEED-9925 - meeds-io/meeds#3820.

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -789,6 +789,7 @@
   line-clamp: 2;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 /* 2 x line-height max.. To not use padding with this */
 .max-height-2lh {
@@ -801,6 +802,7 @@
   line-clamp: 3 !important;
   -webkit-line-clamp: 3 !important;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 /* 3 x line-height max. To not use padding with this */
 .max-height-3lh {


### PR DESCRIPTION
Before this change, when access to App center in extended mode then zoom in to 200%, the application description is truncated and their name extends beyond the border. To fix this problem, add word-break: break-word; to class text-truncate-2 and text-truncate-3. After this change, the application card is displayed in 200% zoom mode.