### PR TITLE
fix: Use default background color when the app background is not defined - MEED-10242 - Meeds-io/meeds#4047

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -896,7 +896,7 @@
 }
 
 .linear-gradient-app-background {
-  background: linear-gradient(to left, var(--appBackgroundColor) 80%, rgba(255, 255, 255, 0) 100%);
+  background: linear-gradient(to left, var(--appBackgroundColor, #fff) 80%, rgba(255, 255, 255, 0) 100%);
 }
 
 .hidden-space {


### PR DESCRIPTION
This change will use a default background color when the app background is not defined.

Resolves: Meeds-io/meeds#4047