### PR TITLE
fix: Fix top bar disappearing during drag applications - MEED-10311 - Meeds-io/meeds#4124

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
@@ -294,6 +294,7 @@
 }
 .scroll-top .layout-sticky-top-bar {
   z-index: 10;
+  position: fixed !important;
 }
 
 .application-align-v-end,


### PR DESCRIPTION
This change will ensure the header remains visible and on top during edit layout.