### PR TITLE
fix: Fix top bar icons position issue when scrolling down - MEED-10339 - Meeds-io/meeds#4149

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
@@ -294,7 +294,6 @@
 }
 .scroll-top .layout-sticky-top-bar {
   z-index: 10;
-  position: fixed !important;
 }
 
 .application-align-v-end,


### PR DESCRIPTION
This change will revert the fix made in [pr](https://github.com/Meeds-io/platform-ui/pull/967) as it makes icons position not ok when scrolling down