### PR TITLE
fix: fully display menus attached inside sticky applications - EXO-88407

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/layout/pagelayout.less
@@ -321,6 +321,10 @@
   .VuetifyApp .v-application .layout-sticky-application .flex-cell > :last-of-type {
     position: sticky;
     top: 0.1px;
+
+    &:has(.menuable__content__active) {
+      z-index: 2;
+    }
   }
 }
 


### PR DESCRIPTION
Sticky applications (default for flex layout sections) are stacking contexts painted in DOM order, so a menu attached inside an application (date picker, select...) was displayed under the applications of the sections below, whatever its own z-index. Raise the application holding an open menu above its siblings, reverting once the menu closes.