### PR TITLE
feat: add text background CSS support - EXO-88488

### DIFF
--- a/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/core/helpers.less
@@ -152,6 +152,96 @@
 .text-subtitle-color {
   color: @textSubtitleColor !important;
 }
+// The Text Background "Margin" option insets the background away from the
+// text edges WITHOUT moving the text itself (same intent as the dedicated
+// app/section background layer added in EXIP-88427). Padding on the text
+// element itself would shift the text and, since these classes are used
+// all over the platform (menu items, list tiles...) that already rely on
+// their own real padding, forcing any padding/background there whenever
+// this feature is left unconfigured previously broke unrelated spacing
+// (EXIP-88488). So the background/margin/radius live entirely on a ::before
+// positioned behind the text via negative insets - :where() keeps its
+// specificity at (0,0,1), lower than any component's own ::before (e.g.
+// Vuetify's hover/ripple overlays), so this only paints where nothing else
+// already claims that pseudo-element, and never touches the text's own box.
+:where(.text-title, .text-header-title, .text-title-color)::before {
+  content: "";
+  position: absolute;
+  top: @textTitleBackgroundInsetTop;
+  right: @textTitleBackgroundInsetRight;
+  bottom: @textTitleBackgroundInsetBottom;
+  left: @textTitleBackgroundInsetLeft;
+  z-index: -1;
+  pointer-events: none;
+  background-color: @textTitleBackgroundColor;
+  background-image: @textTitleBackgroundImage;
+  background-position: @textTitleBackgroundPosition;
+  background-size: @textTitleBackgroundSize;
+  background-repeat: @textTitleBackgroundRepeat;
+  border-radius: @textTitleBackgroundRadius;
+}
+:where(.text-header, .widget-text-header, .text-header-color)::before {
+  content: "";
+  position: absolute;
+  top: @textHeaderBackgroundInsetTop;
+  right: @textHeaderBackgroundInsetRight;
+  bottom: @textHeaderBackgroundInsetBottom;
+  left: @textHeaderBackgroundInsetLeft;
+  z-index: -1;
+  pointer-events: none;
+  background-color: @textHeaderBackgroundColor;
+  background-image: @textHeaderBackgroundImage;
+  background-position: @textHeaderBackgroundPosition;
+  background-size: @textHeaderBackgroundSize;
+  background-repeat: @textHeaderBackgroundRepeat;
+  border-radius: @textHeaderBackgroundRadius;
+}
+:where(.text-body, .text-color)::before {
+  content: "";
+  position: absolute;
+  top: @textBackgroundInsetTop;
+  right: @textBackgroundInsetRight;
+  bottom: @textBackgroundInsetBottom;
+  left: @textBackgroundInsetLeft;
+  z-index: -1;
+  pointer-events: none;
+  background-color: @textBackgroundColor;
+  background-image: @textBackgroundImage;
+  background-position: @textBackgroundPosition;
+  background-size: @textBackgroundSize;
+  background-repeat: @textBackgroundRepeat;
+  border-radius: @textBackgroundRadius;
+}
+:where(.text-subtitle, .text-subtitle-color)::before {
+  content: "";
+  position: absolute;
+  top: @textSubtitleBackgroundInsetTop;
+  right: @textSubtitleBackgroundInsetRight;
+  bottom: @textSubtitleBackgroundInsetBottom;
+  left: @textSubtitleBackgroundInsetLeft;
+  z-index: -1;
+  pointer-events: none;
+  background-color: @textSubtitleBackgroundColor;
+  background-image: @textSubtitleBackgroundImage;
+  background-position: @textSubtitleBackgroundPosition;
+  background-size: @textSubtitleBackgroundSize;
+  background-repeat: @textSubtitleBackgroundRepeat;
+  border-radius: @textSubtitleBackgroundRadius;
+}
+// Establishes the positioning AND stacking context the ::before layers above
+// anchor to and render behind. z-index needs an explicit value (not auto) or
+// this element doesn't form its own stacking context, and the ::before's
+// z-index: -1 escapes to whatever ancestor DOES form one instead - painting
+// behind that far-away ancestor's own descendants rather than just this
+// element's own text, which can land it behind an unrelated opaque
+// background several levels up and make it invisible. :where() so this only
+// kicks in where nothing else already manages this element's position/stack.
+:where(.text-title, .text-header, .text-body, .text-subtitle,
+       .text-header-title, .widget-text-header,
+       .text-title-color, .text-header-color, .text-color, .text-subtitle-color) {
+  position: relative;
+  z-index: 0;
+}
 .text-disabled-color {
   color: @textDisabledColor !important;
 }

--- a/platform-ui-skin/src/main/webapp/skin/less/variables.less
+++ b/platform-ui-skin/src/main/webapp/skin/less/variables.less
@@ -161,6 +161,16 @@
 @textTitleFontWeight: ~"var(--appTextTitleFontWeight, var(--allPagesBaseTextTitleFontWeight, @{textTitleFontWeightDefault}))";
 @textTitleFontStyleDefault: normal;
 @textTitleFontStyle: ~"var(--appTextTitleFontStyle, var(--allPagesBaseTextTitleFontStyle, @{textTitleFontStyleDefault}))";
+@textTitleBackgroundColor: ~"var(--appTextTitleBackgroundColor, transparent)";
+@textTitleBackgroundImage: ~"var(--appTextTitleBackgroundImage, none)";
+@textTitleBackgroundPosition: ~"var(--appTextTitleBackgroundPosition, unset)";
+@textTitleBackgroundSize: ~"var(--appTextTitleBackgroundSize, unset)";
+@textTitleBackgroundRepeat: ~"var(--appTextTitleBackgroundRepeat, no-repeat)";
+@textTitleBackgroundInsetTop: ~"calc(-1 * var(--appTextTitleBackgroundPaddingTop, 0px))";
+@textTitleBackgroundInsetRight: ~"calc(-1 * var(--appTextTitleBackgroundPaddingRight, 0px))";
+@textTitleBackgroundInsetBottom: ~"calc(-1 * var(--appTextTitleBackgroundPaddingBottom, 0px))";
+@textTitleBackgroundInsetLeft: ~"calc(-1 * var(--appTextTitleBackgroundPaddingLeft, 0px))";
+@textTitleBackgroundRadius: ~"var(--appTextTitleBackgroundRadius, 0)";
 
 @textHeaderColorDefault: #707070;
 @textHeaderColor: ~"var(--appTextHeaderColor, var(--allPagesBaseTextHeaderColor, @{textHeaderColorDefault}))";
@@ -170,6 +180,16 @@
 @textHeaderFontWeight: ~"var(--appTextHeaderFontWeight, var(--allPagesBaseTextHeaderFontWeight, @{textHeaderFontWeightDefault}))";
 @textHeaderFontStyleDefault: normal;
 @textHeaderFontStyle: ~"var(--appTextHeaderFontStyle, var(--allPagesBaseTextHeaderFontStyle, @{textHeaderFontStyleDefault}))";
+@textHeaderBackgroundColor: ~"var(--appTextHeaderBackgroundColor, transparent)";
+@textHeaderBackgroundImage: ~"var(--appTextHeaderBackgroundImage, none)";
+@textHeaderBackgroundPosition: ~"var(--appTextHeaderBackgroundPosition, unset)";
+@textHeaderBackgroundSize: ~"var(--appTextHeaderBackgroundSize, unset)";
+@textHeaderBackgroundRepeat: ~"var(--appTextHeaderBackgroundRepeat, no-repeat)";
+@textHeaderBackgroundInsetTop: ~"calc(-1 * var(--appTextHeaderBackgroundPaddingTop, 0px))";
+@textHeaderBackgroundInsetRight: ~"calc(-1 * var(--appTextHeaderBackgroundPaddingRight, 0px))";
+@textHeaderBackgroundInsetBottom: ~"calc(-1 * var(--appTextHeaderBackgroundPaddingBottom, 0px))";
+@textHeaderBackgroundInsetLeft: ~"calc(-1 * var(--appTextHeaderBackgroundPaddingLeft, 0px))";
+@textHeaderBackgroundRadius: ~"var(--appTextHeaderBackgroundRadius, 0)";
 
 @textColorDefault: #20282c;
 @textColor: ~"var(--appTextColor, var(--allPagesBaseTextColor, @{textColorDefault}))";
@@ -179,6 +199,16 @@
 @textFontWeight: ~"var(--appTextFontWeight, var(--allPagesBaseTextFontWeight, @{textFontWeightDefault}))";
 @textFontStyleDefault: normal;
 @textFontStyle: ~"var(--appTextFontStyle, var(--allPagesBaseTextFontStyle, @{textFontStyleDefault}))";
+@textBackgroundColor: ~"var(--appTextBackgroundColor, transparent)";
+@textBackgroundImage: ~"var(--appTextBackgroundImage, none)";
+@textBackgroundPosition: ~"var(--appTextBackgroundPosition, unset)";
+@textBackgroundSize: ~"var(--appTextBackgroundSize, unset)";
+@textBackgroundRepeat: ~"var(--appTextBackgroundRepeat, no-repeat)";
+@textBackgroundInsetTop: ~"calc(-1 * var(--appTextBackgroundPaddingTop, 0px))";
+@textBackgroundInsetRight: ~"calc(-1 * var(--appTextBackgroundPaddingRight, 0px))";
+@textBackgroundInsetBottom: ~"calc(-1 * var(--appTextBackgroundPaddingBottom, 0px))";
+@textBackgroundInsetLeft: ~"calc(-1 * var(--appTextBackgroundPaddingLeft, 0px))";
+@textBackgroundRadius: ~"var(--appTextBackgroundRadius, 0)";
 
 @textSubtitleColorDefault: #707070;
 @textSubtitleColor: ~"var(--appTextSubtitleColor, var(--allPagesBaseTextSubtitleColor, @{textSubtitleColorDefault}))";
@@ -188,6 +218,16 @@
 @textSubtitleFontWeight: ~"var(--appTextSubtitleFontWeight, var(--allPagesBaseTextSubtitleFontWeight, @{textSubtitleFontWeightDefault}))";
 @textSubtitleFontStyleDefault: normal;
 @textSubtitleFontStyle: ~"var(--appTextSubtitleFontStyle, var(--allPagesBaseTextSubtitleFontStyle, @{textSubtitleFontStyleDefault}))";
+@textSubtitleBackgroundColor: ~"var(--appTextSubtitleBackgroundColor, transparent)";
+@textSubtitleBackgroundImage: ~"var(--appTextSubtitleBackgroundImage, none)";
+@textSubtitleBackgroundPosition: ~"var(--appTextSubtitleBackgroundPosition, unset)";
+@textSubtitleBackgroundSize: ~"var(--appTextSubtitleBackgroundSize, unset)";
+@textSubtitleBackgroundRepeat: ~"var(--appTextSubtitleBackgroundRepeat, no-repeat)";
+@textSubtitleBackgroundInsetTop: ~"calc(-1 * var(--appTextSubtitleBackgroundPaddingTop, 0px))";
+@textSubtitleBackgroundInsetRight: ~"calc(-1 * var(--appTextSubtitleBackgroundPaddingRight, 0px))";
+@textSubtitleBackgroundInsetBottom: ~"calc(-1 * var(--appTextSubtitleBackgroundPaddingBottom, 0px))";
+@textSubtitleBackgroundInsetLeft: ~"calc(-1 * var(--appTextSubtitleBackgroundPaddingLeft, 0px))";
+@textSubtitleBackgroundRadius: ~"var(--appTextSubtitleBackgroundRadius, 0)";
 
 @textDisabledColorDefault: #c6c6c6;
 @textDisabledColor: ~"var(--appTextDisabledColor, var(--allPagesBaseTextDisabledColor, @{textDisabledColorDefault}))";


### PR DESCRIPTION
Extends .text-title/.text-header/.text-body/.text-subtitle (and their widget-text-header/text-header-title/-color aliases) with a background layer painted behind the text via a ::before pseudo-element inset by negative margins, so configuring background/margin/radius never shifts the text itself.